### PR TITLE
支持基金和股票成本价，持仓，收益率，收益显示

### DIFF
--- a/src/main/java/FundWindow.java
+++ b/src/main/java/FundWindow.java
@@ -169,7 +169,8 @@ public class FundWindow implements ToolWindowFactory {
     }
 
     private static List<String> loadFunds() {
-        return getConfigList("key_funds", "[;]");
+//        return getConfigList("key_funds", "[,，]");
+        return getConfigList("key_funds");
     }
 
     public static List<String> getConfigList(String key, String split) {
@@ -179,6 +180,26 @@ public class FundWindow implements ToolWindowFactory {
         }
         Set<String> set = new LinkedHashSet<>();
         String[] codes = value.split(split);
+        for (String code : codes) {
+            if (!code.isEmpty()) {
+                set.add(code.trim());
+            }
+        }
+        return new ArrayList<>(set);
+    }
+
+    public static List<String> getConfigList(String key) {
+        String value = PropertiesComponent.getInstance().getValue(key);
+        if (StringUtils.isEmpty(value)) {
+            return new ArrayList<>();
+        }
+        Set<String> set = new LinkedHashSet<>();
+        String[] codes = null;
+        if (value.contains(";")) {//包含分号
+            codes = value.split("[;]");
+        } else {
+            codes = value.split("[,，]");
+        }
         for (String code : codes) {
             if (!code.isEmpty()) {
                 set.add(code.trim());

--- a/src/main/java/FundWindow.java
+++ b/src/main/java/FundWindow.java
@@ -15,22 +15,24 @@ import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentFactory;
 import com.intellij.ui.content.ContentManager;
 import com.intellij.ui.table.JBTable;
+import handler.TianTianFundHandler;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import utils.HttpClientPool;
 import utils.LogUtil;
-import handler.TianTianFundHandler;
 import utils.PopupsUiUtil;
 import utils.WindowUtils;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
-import java.awt.event.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionAdapter;
 import java.net.MalformedURLException;
-import java.util.*;
 import java.util.List;
+import java.util.*;
 
 public class FundWindow implements ToolWindowFactory {
     private JPanel mPanel;
@@ -167,7 +169,7 @@ public class FundWindow implements ToolWindowFactory {
     }
 
     private static List<String> loadFunds() {
-        return getConfigList("key_funds", "[,，]");
+        return getConfigList("key_funds", "[;]");
     }
 
     public static List<String> getConfigList(String key, String split) {

--- a/src/main/java/SettingsWindow.form
+++ b/src/main/java/SettingsWindow.form
@@ -66,7 +66,7 @@
                   <forms defaultalign-vert="false"/>
                 </constraints>
                 <properties>
-                  <text value="基金编码，英文逗号分隔："/>
+                  <text value="基金编码，英文分号分隔（持仓成本价和持仓份额跟在基金编码后，用英文逗号分隔）："/>
                 </properties>
               </component>
               <scrollpane id="f10a8">
@@ -85,7 +85,7 @@
                       <preferredSize width="370" height="190"/>
                       <rows value="10"/>
                       <text value=""/>
-                      <toolTipText value="基金编码，英文逗号分隔"/>
+                      <toolTipText value="基金编码，英文分号分隔（持仓成本价和持仓份额跟在基金编码后，用英文逗号分隔），例如:{001632,3.2050,951.64;002340,4.2820,467.07}"/>
                     </properties>
                   </component>
                 </children>
@@ -133,7 +133,7 @@
                   <forms defaultalign-vert="false"/>
                 </constraints>
                 <properties>
-                  <text value="股票编码，英文逗号分隔："/>
+                  <text value="股票编码，英文分号分隔（成本价和持仓接在编码后用逗号分隔）："/>
                 </properties>
               </component>
               <scrollpane id="e0430">
@@ -151,7 +151,7 @@
                       <minimumSize width="370" height="17"/>
                       <preferredSize width="370" height="190"/>
                       <rows value="10"/>
-                      <toolTipText value="股票编码，英文逗号分隔，例如：【sh000001,sh600519,sz000001,hk00700,usAAPL】"/>
+                      <toolTipText value="股票编码，英文逗号分隔，例如：【sh000001,12.451,1200;hk00700,13.412,2000】"/>
                     </properties>
                     <clientProperties>
                       <html.disable class="java.lang.Boolean" value="false"/>

--- a/src/main/java/StockWindow.java
+++ b/src/main/java/StockWindow.java
@@ -171,7 +171,8 @@ public class StockWindow {
     }
 
     private static List<String> loadStocks(){
-        return FundWindow.getConfigList("key_stocks", "[;]");
+//        return FundWindow.getConfigList("key_stocks", "[,，]");
+        return FundWindow.getConfigList("key_stocks");
     }
 
 }

--- a/src/main/java/StockWindow.java
+++ b/src/main/java/StockWindow.java
@@ -9,10 +9,10 @@ import com.intellij.ui.AnActionButton;
 import com.intellij.ui.ToolbarDecorator;
 import com.intellij.ui.awt.RelativePoint;
 import com.intellij.ui.table.JBTable;
-import org.jetbrains.annotations.NotNull;
 import handler.SinaStockHandler;
 import handler.StockRefreshHandler;
 import handler.TencentStockHandler;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import utils.LogUtil;
 import utils.PopupsUiUtil;
@@ -171,7 +171,7 @@ public class StockWindow {
     }
 
     private static List<String> loadStocks(){
-        return FundWindow.getConfigList("key_stocks", "[,，]");
+        return FundWindow.getConfigList("key_stocks", "[;]");
     }
 
 }

--- a/src/main/java/bean/FundBean.java
+++ b/src/main/java/bean/FundBean.java
@@ -46,9 +46,9 @@ public class FundBean {
         this.fundName = "--";
     }
 
-    public static void loadFund(FundBean fund, Map<String, String[]> codeMap){
+    public static void loadFund(FundBean fund, Map<String, String[]> codeMap) {
         String code = fund.getFundCode();
-        if(codeMap.containsKey(code)){
+        if (codeMap.containsKey(code)) {
             String[] codeStr = codeMap.get(code);
             if (codeStr.length > 2) {
                 fund.setCostPrise(codeStr[1]);
@@ -161,7 +161,8 @@ public class FundBean {
 
     /**
      * 返回列名的VALUE 用作展示
-     * @param colums 字段名
+     *
+     * @param colums   字段名
      * @param colorful 隐蔽模式
      * @return 对应列名的VALUE值 无法匹配返回""
      */
@@ -197,7 +198,7 @@ public class FundBean {
             case "持有份额":
                 return this.getBonds();
             case "收益率":
-                return this.getIncomePercent() + "%";
+                return this.getCostPrise() != null ? this.getIncomePercent() + "%" : this.getCostPrise();
             case "收益":
                 return this.getIncome();
             default:

--- a/src/main/java/bean/FundBean.java
+++ b/src/main/java/bean/FundBean.java
@@ -198,7 +198,7 @@ public class FundBean {
             case "持有份额":
                 return this.getBonds();
             case "收益率":
-                return this.getCostPrise() != null ? this.getIncomePercent() + "%" : this.getCostPrise();
+                return this.getCostPrise() != null ? this.getIncomePercent() + "%" : this.getIncomePercent();
             case "收益":
                 return this.getIncome();
             default:

--- a/src/main/java/bean/FundBean.java
+++ b/src/main/java/bean/FundBean.java
@@ -1,10 +1,12 @@
 package bean;
 
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.StringUtils;
 import utils.PinYinUtils;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Map;
 import java.util.Objects;
 
 public class FundBean {
@@ -18,13 +20,41 @@ public class FundBean {
     private String gszzl;//估算涨跌百分比 即-0.42%
     private String gztime;//gztime估值时间
 
+    private String costPrise;//持仓成本价
+    private String bonds;//持有份额
+    private String incomePercent;//收益率
+    private String income;//收益
+
     public FundBean() {
     }
 
     public FundBean(String fundCode) {
-        this.fundCode = fundCode;
+        if (StringUtils.isNotBlank(fundCode)) {
+            String[] codeStr = fundCode.split(",");
+            if (codeStr.length > 2) {
+                this.fundCode = codeStr[0];
+                this.costPrise = codeStr[1];
+                this.bonds = codeStr[2];
+            } else {
+                this.fundCode = codeStr[0];
+                this.costPrise = "--";
+                this.bonds = "--";
+            }
+        } else {
+            this.fundCode = fundCode;
+        }
         this.fundName = "--";
+    }
 
+    public static void loadFund(FundBean fund, Map<String, String[]> codeMap){
+        String code = fund.getFundCode();
+        if(codeMap.containsKey(code)){
+            String[] codeStr = codeMap.get(code);
+            if (codeStr.length > 2) {
+                fund.setCostPrise(codeStr[1]);
+                fund.setBonds(codeStr[2]);
+            }
+        }
     }
 
 
@@ -84,6 +114,38 @@ public class FundBean {
         this.gztime = gztime;
     }
 
+    public String getCostPrise() {
+        return costPrise;
+    }
+
+    public void setCostPrise(String costPrise) {
+        this.costPrise = costPrise;
+    }
+
+    public String getBonds() {
+        return bonds;
+    }
+
+    public void setBonds(String bonds) {
+        this.bonds = bonds;
+    }
+
+    public String getIncomePercent() {
+        return incomePercent;
+    }
+
+    public void setIncomePercent(String incomePercent) {
+        this.incomePercent = incomePercent;
+    }
+
+    public String getIncome() {
+        return income;
+    }
+
+    public void setIncome(String income) {
+        this.income = income;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -130,6 +192,14 @@ public class FundBean {
                 return timeStr;
             case "当日净值":
                 return this.getDwjz() + "[" + this.getJzrq() + "]";
+            case "持仓成本价":
+                return this.getCostPrise();
+            case "持有份额":
+                return this.getBonds();
+            case "收益率":
+                return this.getIncomePercent() + "%";
+            case "收益":
+                return this.getIncome();
             default:
                 return "";
 

--- a/src/main/java/bean/StockBean.java
+++ b/src/main/java/bean/StockBean.java
@@ -221,7 +221,7 @@ public class StockBean {
             case "持仓":
                 return this.getBonds();
             case "收益率":
-                return this.getCostPrise() != null ? this.getIncomePercent() + "%" : this.getCostPrise();
+                return this.getCostPrise() != null ? this.getIncomePercent() + "%" : this.getIncomePercent();
             case "收益":
                 return this.getIncome();
             case "更新时间":

--- a/src/main/java/bean/StockBean.java
+++ b/src/main/java/bean/StockBean.java
@@ -218,12 +218,10 @@ public class StockBean {
                 return this.getMin();
             case "成本价":
                 return this.getCostPrise();
-//            case "成本":
-//                return this.getCost();
             case "持仓":
                 return this.getBonds();
             case "收益率":
-                return this.getIncomePercent() + "%";
+                return this.getCostPrise() != null ? this.getIncomePercent() + "%" : this.getCostPrise();
             case "收益":
                 return this.getIncome();
             case "更新时间":

--- a/src/main/java/bean/StockBean.java
+++ b/src/main/java/bean/StockBean.java
@@ -1,9 +1,11 @@
 package bean;
 
+import org.apache.commons.lang3.StringUtils;
 import utils.PinYinUtils;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Map;
 import java.util.Objects;
 
 public class StockBean {
@@ -22,12 +24,47 @@ public class StockBean {
      */
     private String min;
 
+    private String costPrise;//成本价
+//    private String cost;//成本
+    private String bonds;//持仓
+    private String incomePercent;//收益率
+    private String income;//收益
+
     public StockBean() {
     }
 
+    //配置code同时配置成本价和成本值
     public StockBean(String code) {
-        this.code = code;
+        if (StringUtils.isNotBlank(code)) {
+            String[] codeStr = code.split(",");
+            if (codeStr.length > 2) {
+                this.code = codeStr[0];
+                this.costPrise = codeStr[1];
+//                this.cost = codeStr[2];
+                this.bonds = codeStr[2];
+            } else {
+                this.code = codeStr[0];
+                this.costPrise = "--";
+//                this.cost = "--";
+                this.bonds = "--";
+            }
+        } else {
+            this.code = code;
+        }
         this.name = "--";
+    }
+
+    public StockBean(String code, Map<String, String[]> codeMap){
+        this.code = code;
+        if(codeMap.containsKey(code)){
+            String[] codeStr = codeMap.get(code);
+            if (codeStr.length > 2) {
+                this.code = codeStr[0];
+                this.costPrise = codeStr[1];
+//                this.cost = codeStr[2];
+                this.bonds = codeStr[2];
+            }
+        }
     }
 
     public String getCode() {
@@ -94,6 +131,46 @@ public class StockBean {
         this.min = min;
     }
 
+    public String getCostPrise() {
+        return costPrise;
+    }
+
+    public void setCostPrise(String costPrise) {
+        this.costPrise = costPrise;
+    }
+
+    public String getBonds() {
+        return bonds;
+    }
+
+    public void setBonds(String bonds) {
+        this.bonds = bonds;
+    }
+
+    //    public String getCost() {
+//        return cost;
+//    }
+//
+//    public void setCost(String cost) {
+//        this.cost = cost;
+//    }
+
+    public String getIncomePercent() {
+        return incomePercent;
+    }
+
+    public void setIncomePercent(String incomePercent) {
+        this.incomePercent = incomePercent;
+    }
+
+    public String getIncome() {
+        return income;
+    }
+
+    public void setIncome(String income) {
+        this.income = income;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -110,7 +187,8 @@ public class StockBean {
 
     /**
      * 返回列名的VALUE 用作展示
-     * @param colums 字段名
+     *
+     * @param colums   字段名
      * @param colorful 隐蔽模式
      * @return 对应列名的VALUE值 无法匹配返回""
      */
@@ -137,7 +215,17 @@ public class StockBean {
             case "最高价":
                 return this.getMax();
             case "最低价":
-                return this.getMin() ;
+                return this.getMin();
+            case "成本价":
+                return this.getCostPrise();
+//            case "成本":
+//                return this.getCost();
+            case "持仓":
+                return this.getBonds();
+            case "收益率":
+                return this.getIncomePercent() + "%";
+            case "收益":
+                return this.getIncome();
             case "更新时间":
                 String timeStr = "--";
                 if (this.getTime() != null) {

--- a/src/main/java/handler/FundRefreshHandler.java
+++ b/src/main/java/handler/FundRefreshHandler.java
@@ -1,11 +1,11 @@
 package handler;
 
+import bean.FundBean;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.table.JBTable;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
-import bean.FundBean;
 import utils.PinYinUtils;
 import utils.WindowUtils;
 
@@ -14,8 +14,8 @@ import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableRowSorter;
 import java.awt.*;
-import java.util.*;
 import java.util.List;
+import java.util.*;
 
 public abstract class FundRefreshHandler extends DefaultTableModel {
     private static String[] columnNames;
@@ -145,7 +145,14 @@ public abstract class FundRefreshHandler extends DefaultTableModel {
         };
 //        table.getColumn(getColumnName(2)).setCellRenderer(cellRenderer);
         int columnIndex = WindowUtils.getColumnIndexByName(columnNames, "估算涨跌");
+
+        int columnIndex3 = WindowUtils.getColumnIndexByName(columnNames, "收益率");
+        int columnIndex4 = WindowUtils.getColumnIndexByName(columnNames, "收益");
+
         table.getColumn(getColumnName(columnIndex)).setCellRenderer(cellRenderer);
+
+        table.getColumn(getColumnName(columnIndex3)).setCellRenderer(cellRenderer);
+        table.getColumn(getColumnName(columnIndex4)).setCellRenderer(cellRenderer);
     }
 
     protected void updateData(FundBean bean) {

--- a/src/main/java/handler/SinaStockHandler.java
+++ b/src/main/java/handler/SinaStockHandler.java
@@ -59,7 +59,13 @@ public class SinaStockHandler extends StockRefreshHandler {
         List<String> codeList = new ArrayList<>();
         Map<String, String[]> codeMap = new HashMap<>();
         for (String str : code) {
-            String[] strArray = str.split(",");
+            //兼容原有设置
+            String[] strArray;
+            if (str.contains(",")) {
+                strArray = str.split(",");
+            } else {
+                strArray = new String[]{str};
+            }
             codeList.add(strArray[0]);
             codeMap.put(strArray[0], strArray);
         }

--- a/src/main/java/handler/SinaStockHandler.java
+++ b/src/main/java/handler/SinaStockHandler.java
@@ -1,8 +1,9 @@
 package handler;
 
+import bean.StockBean;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
-import bean.StockBean;
+import org.apache.commons.lang.StringUtils;
 import utils.HttpClientPool;
 import utils.LogUtil;
 
@@ -10,7 +11,9 @@ import javax.swing.*;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -39,7 +42,7 @@ public class SinaStockHandler extends StockRefreshHandler {
     }
 
     public void useScheduleThreadExecutor(List<String> code) {
-        if (mSchedulerExecutor.isShutdown()){
+        if (mSchedulerExecutor.isShutdown()) {
             mSchedulerExecutor = Executors.newSingleThreadScheduledExecutor();
         }
         mSchedulerExecutor.scheduleAtFixedRate(getWork(code), 0, threadSleepTime, TimeUnit.SECONDS);
@@ -52,18 +55,27 @@ public class SinaStockHandler extends StockRefreshHandler {
     }
 
     private void pollStock(List<String> code) {
-        String params = Joiner.on(",").join(code);
+        //股票编码，英文分号分隔（成本价和成本接在编码后用逗号分隔）
+        List<String> codeList = new ArrayList<>();
+        Map<String, String[]> codeMap = new HashMap<>();
+        for (String str : code) {
+            String[] strArray = str.split(",");
+            codeList.add(strArray[0]);
+            codeMap.put(strArray[0], strArray);
+        }
+
+        String params = Joiner.on(",").join(codeList);
         try {
             String res = HttpClientPool.getHttpClient().get(URL + params);
 //            String time = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss,SSS"));
 //            System.out.printf("%s,%s%n", time, res);
-            handleResponse(res);
+            handleResponse(res, codeMap);
         } catch (Exception e) {
             LogUtil.info(e.getMessage());
         }
     }
 
-    public void handleResponse(String response) {
+    public void handleResponse(String response, Map<String, String[]> codeMap) {
         List<String> refreshTimeList = new ArrayList<>();
         for (String line : response.split("\n")) {
             Matcher matcher = DEFAULT_STOCK_PATTERN.matcher(line);
@@ -75,7 +87,7 @@ public class SinaStockHandler extends StockRefreshHandler {
             if (split.length < 32) {
                 continue;
             }
-            StockBean bean = new StockBean(code);
+            StockBean bean = new StockBean(code, codeMap);
             bean.setName(split[0]);
             BigDecimal now = new BigDecimal(split[3]);
             BigDecimal yesterday = new BigDecimal(split[2]);
@@ -91,6 +103,28 @@ public class SinaStockHandler extends StockRefreshHandler {
             bean.setTime(Strings.repeat("0", 8) + split[31]);
             bean.setMax(split[4]);
             bean.setMin(split[5]);
+
+            String costPriceStr = bean.getCostPrise();
+            if (StringUtils.isNotEmpty(costPriceStr)) {
+                BigDecimal costPriceDec = new BigDecimal(costPriceStr);
+                BigDecimal incomeDiff = now.add(costPriceDec.negate());
+                BigDecimal incomePercentDec = incomeDiff.divide(costPriceDec, 5, RoundingMode.HALF_UP)
+                        .multiply(BigDecimal.TEN)
+                        .multiply(BigDecimal.TEN)
+                        .setScale(3, RoundingMode.HALF_UP);
+                bean.setIncomePercent(incomePercentDec.toString());
+
+                String bondStr = bean.getBonds();
+                if (StringUtils.isNotEmpty(bondStr)) {
+                    BigDecimal bondDec = new BigDecimal(bondStr);
+                    BigDecimal incomeDec = incomeDiff.divide(costPriceDec, 5, RoundingMode.HALF_UP)
+                            .multiply(bondDec)
+                            .multiply(now)
+                            .setScale(2, RoundingMode.HALF_UP);
+                    bean.setIncome(incomeDec.toString());
+                }
+            }
+
             updateData(bean);
             refreshTimeList.add(split[31]);
         }

--- a/src/main/java/handler/StockRefreshHandler.java
+++ b/src/main/java/handler/StockRefreshHandler.java
@@ -1,11 +1,11 @@
 package handler;
 
+import bean.StockBean;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.table.JBTable;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
-import bean.StockBean;
 import utils.PinYinUtils;
 import utils.WindowUtils;
 
@@ -14,8 +14,8 @@ import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableRowSorter;
 import java.awt.*;
-import java.util.*;
 import java.util.List;
+import java.util.*;
 
 public abstract class StockRefreshHandler extends DefaultTableModel {
     private static String[] columnNames;
@@ -146,8 +146,15 @@ public abstract class StockRefreshHandler extends DefaultTableModel {
         };
         int columnIndex1 = WindowUtils.getColumnIndexByName(columnNames, "涨跌");
         int columnIndex2 = WindowUtils.getColumnIndexByName(columnNames, "涨跌幅");
+
+        int columnIndex3 = WindowUtils.getColumnIndexByName(columnNames, "收益率");
+        int columnIndex4 = WindowUtils.getColumnIndexByName(columnNames, "收益");
+
         table.getColumn(getColumnName(columnIndex1)).setCellRenderer(cellRenderer);
         table.getColumn(getColumnName(columnIndex2)).setCellRenderer(cellRenderer);
+
+        table.getColumn(getColumnName(columnIndex3)).setCellRenderer(cellRenderer);
+        table.getColumn(getColumnName(columnIndex4)).setCellRenderer(cellRenderer);
     }
 
     protected void updateData(StockBean bean) {

--- a/src/main/java/handler/TencentStockHandler.java
+++ b/src/main/java/handler/TencentStockHandler.java
@@ -28,18 +28,18 @@ public class TencentStockHandler extends StockRefreshHandler {
     @Override
     public void handle(List<String> code) {
 
-        if (worker!=null){
+        if (worker != null) {
             worker.interrupt();
         }
         LogUtil.info("Leeks 更新Stock编码数据.");
 //        clearRow();
-        if (code.isEmpty()){
+        if (code.isEmpty()) {
             return;
         }
         worker = new Thread(new Runnable() {
             @Override
             public void run() {
-                while (worker!=null && worker.hashCode() == Thread.currentThread().hashCode() && !worker.isInterrupted()){
+                while (worker != null && worker.hashCode() == Thread.currentThread().hashCode() && !worker.isInterrupted()) {
                     stepAction();
                     try {
                         Thread.sleep(threadSleepTime * 1000);
@@ -56,7 +56,13 @@ public class TencentStockHandler extends StockRefreshHandler {
         List<String> codeList = new ArrayList<>();
         codeMap = new HashMap<>();
         for (String str : code) {
-            String[] strArray = str.split(",");
+            //兼容原有设置
+            String[] strArray;
+            if (str.contains(",")) {
+                strArray = str.split(",");
+            } else {
+                strArray = new String[]{str};
+            }
             codeList.add(strArray[0]);
             codeMap.put(strArray[0], strArray);
         }
@@ -84,11 +90,11 @@ public class TencentStockHandler extends StockRefreshHandler {
 //            }
 //            return;
 //        }
-        if (StringUtils.isEmpty(urlPara)){
+        if (StringUtils.isEmpty(urlPara)) {
             return;
         }
         try {
-            String result = HttpClientPool.getHttpClient().get("http://qt.gtimg.cn/q="+urlPara);
+            String result = HttpClientPool.getHttpClient().get("http://qt.gtimg.cn/q=" + urlPara);
             parse(result);
             updateUI();
         } catch (Exception e) {
@@ -99,8 +105,8 @@ public class TencentStockHandler extends StockRefreshHandler {
     private void parse(String result) {
         String[] lines = result.split("\n");
         for (String line : lines) {
-            String code = line.substring(line.indexOf("_")+1,line.indexOf("="));
-            String dataStr = line.substring(line.indexOf("=")+2,line.length()-2);
+            String code = line.substring(line.indexOf("_") + 1, line.indexOf("="));
+            String dataStr = line.substring(line.indexOf("=") + 2, line.length() - 2);
             String[] values = dataStr.split("~");
             StockBean bean = new StockBean(code, codeMap);
             bean.setName(values[1]);

--- a/src/main/java/handler/TianTianFundHandler.java
+++ b/src/main/java/handler/TianTianFundHandler.java
@@ -1,15 +1,20 @@
 package handler;
 
-import com.google.gson.Gson;
 import bean.FundBean;
+import com.google.gson.Gson;
+import org.apache.commons.lang.StringUtils;
 import utils.HttpClientPool;
 import utils.LogUtil;
 
 import javax.swing.*;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class TianTianFundHandler extends FundRefreshHandler {
     public final static DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss");
@@ -30,20 +35,20 @@ public class TianTianFundHandler extends FundRefreshHandler {
 
     @Override
     public void handle(List<String> code) {
-        if (worker!=null){
+        if (worker != null) {
             worker.interrupt();
         }
         LogUtil.info("Leeks 更新Fund编码数据.");
 
-        if (code.isEmpty()){
+        if (code.isEmpty()) {
             return;
         }
 
         worker = new Thread(new Runnable() {
             @Override
             public void run() {
-                while (worker!=null && worker.hashCode() == Thread.currentThread().hashCode() && !worker.isInterrupted()){
-                    synchronized (codes){
+                while (worker != null && worker.hashCode() == Thread.currentThread().hashCode() && !worker.isInterrupted()) {
+                    synchronized (codes) {
                         stepAction();
                     }
                     try {
@@ -56,7 +61,7 @@ public class TianTianFundHandler extends FundRefreshHandler {
                 }
             }
         });
-        synchronized (codes){
+        synchronized (codes) {
             codes.clear();
             codes.addAll(code);
         }
@@ -71,29 +76,59 @@ public class TianTianFundHandler extends FundRefreshHandler {
         }
     }
 
-    private void stepAction(){
+    private void stepAction() {
 //        LogUtil.info("Leeks 刷新基金数据.");
-        for (String s : codes) {
-            new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        String result = HttpClientPool.getHttpClient().get("http://fundgz.1234567.com.cn/js/"+s+".js?rt="+System.currentTimeMillis());
-                        String json = result.substring(8,result.length()-2);
-                        if(!json.isEmpty()){
-                            FundBean bean = gson.fromJson(json,FundBean.class);
-                            updateData(bean);
-                        }else {
-                            LogUtil.info("Fund编码:["+s+"]无法获取数据");
+        List<String> codeList = new ArrayList<>();
+        Map<String, String[]> codeMap = new HashMap<>();
+        for (String str : codes) {
+            String[] strArray = str.split(",");
+            codeList.add(strArray[0]);
+            codeMap.put(strArray[0], strArray);
+        }
+
+        for (String code : codeList) {
+            new Thread(() -> {
+                try {
+                    String result = HttpClientPool.getHttpClient().get("http://fundgz.1234567.com.cn/js/" + code + ".js?rt=" + System.currentTimeMillis());
+                    String json = result.substring(8, result.length() - 2);
+                    if (!json.isEmpty()) {
+                        FundBean bean = gson.fromJson(json, FundBean.class);
+                        FundBean.loadFund(bean, codeMap);
+
+                        BigDecimal now = new BigDecimal(bean.getGsz());
+                        String costPriceStr = bean.getCostPrise();
+                        if (StringUtils.isNotEmpty(costPriceStr)) {
+                            BigDecimal costPriceDec = new BigDecimal(costPriceStr);
+                            BigDecimal incomeDiff = now.add(costPriceDec.negate());
+                            BigDecimal incomePercentDec = incomeDiff.divide(costPriceDec, 8, RoundingMode.HALF_UP)
+                                    .multiply(BigDecimal.TEN)
+                                    .multiply(BigDecimal.TEN)
+                                    .setScale(3, RoundingMode.HALF_UP);
+                            bean.setIncomePercent(incomePercentDec.toString());
+
+                            String bondStr = bean.getBonds();
+                            if (StringUtils.isNotEmpty(bondStr)) {
+                                BigDecimal bondDec = new BigDecimal(bondStr);
+                                BigDecimal incomeDec = incomeDiff.divide(costPriceDec, 8, RoundingMode.HALF_UP)
+                                        .multiply(bondDec)
+                                        .multiply(now)
+                                        .setScale(2, RoundingMode.HALF_UP);
+                                bean.setIncome(incomeDec.toString());
+                            }
                         }
-                    } catch (Exception e) {
-                        e.printStackTrace();
+
+                        updateData(bean);
+                    } else {
+                        LogUtil.info("Fund编码:[" + code + "]无法获取数据");
                     }
+                } catch (Exception e) {
+                    e.printStackTrace();
                 }
             }).start();
         }
         updateUI();
     }
+
     public void updateUI() {
         SwingUtilities.invokeLater(new Runnable() {
             @Override

--- a/src/main/java/handler/TianTianFundHandler.java
+++ b/src/main/java/handler/TianTianFundHandler.java
@@ -81,7 +81,13 @@ public class TianTianFundHandler extends FundRefreshHandler {
         List<String> codeList = new ArrayList<>();
         Map<String, String[]> codeMap = new HashMap<>();
         for (String str : codes) {
-            String[] strArray = str.split(",");
+            //兼容原有设置
+            String[] strArray;
+            if (str.contains(",")) {
+                strArray = str.split(",");
+            } else {
+                strArray = new String[]{str};
+            }
             codeList.add(strArray[0]);
             codeMap.put(strArray[0], strArray);
         }

--- a/src/main/java/utils/WindowUtils.java
+++ b/src/main/java/utils/WindowUtils.java
@@ -10,10 +10,10 @@ import java.util.HashMap;
 public class WindowUtils {
     //基金表头
     public static final String FUND_TABLE_HEADER_KEY = "fund_table_header_key";
-    public static final String FUND_TABLE_HEADER_VALUE = "编码,基金名称,估算净值,估算涨跌,更新时间,当日净值";
+    public static final String FUND_TABLE_HEADER_VALUE = "编码,基金名称,估算涨跌,当日净值,估算净值,持仓成本价,持有份额,收益率,收益,更新时间";
     //股票表头
     public static final String STOCK_TABLE_HEADER_KEY = "stock_table_header_key";
-    public static final String STOCK_TABLE_HEADER_VALUE = "编码,股票名称,当前价,涨跌,涨跌幅,最高价,最低价,更新时间";
+    public static final String STOCK_TABLE_HEADER_VALUE = "编码,股票名称,涨跌,涨跌幅,最高价,最低价,当前价,成本价,持仓,收益率,收益,更新时间";
     //货币表头
     public static final String COIN_TABLE_HEADER_KEY = "coin_table_header_key2";
     public static final String COIN_TABLE_HEADER_VALUE = "编码,当前价,涨跌,涨跌幅,最高价,最低价,更新时间";
@@ -21,20 +21,27 @@ public class WindowUtils {
     private static HashMap<String,String> remapPinYinMap = new HashMap<>();
 
     static {
-        remapPinYinMap.put(PinYinUtils.toPinYin("编码"),"编码");
-        remapPinYinMap.put(PinYinUtils.toPinYin("基金名称"),"基金名称");
-        remapPinYinMap.put(PinYinUtils.toPinYin("估算净值"),"估算净值");
-        remapPinYinMap.put(PinYinUtils.toPinYin("估算涨跌"),"估算涨跌");
-        remapPinYinMap.put(PinYinUtils.toPinYin("更新时间"),"更新时间");
-        remapPinYinMap.put(PinYinUtils.toPinYin("当日净值"),"当日净值");
-        remapPinYinMap.put(PinYinUtils.toPinYin("股票名称"),"股票名称");
-        remapPinYinMap.put(PinYinUtils.toPinYin("当前价"),"当前价");
-        remapPinYinMap.put(PinYinUtils.toPinYin("涨跌"),"涨跌");
-        remapPinYinMap.put(PinYinUtils.toPinYin("涨跌幅"),"涨跌幅");
-        remapPinYinMap.put(PinYinUtils.toPinYin("最高价"),"最高价");
-        remapPinYinMap.put(PinYinUtils.toPinYin("最低价"),"最低价");
-        remapPinYinMap.put(PinYinUtils.toPinYin("名称"),"名称");
+        remapPinYinMap.put(PinYinUtils.toPinYin("编码"), "编码");
+        remapPinYinMap.put(PinYinUtils.toPinYin("基金名称"), "基金名称");
+        remapPinYinMap.put(PinYinUtils.toPinYin("估算净值"), "估算净值");
+        remapPinYinMap.put(PinYinUtils.toPinYin("估算涨跌"), "估算涨跌");
+        remapPinYinMap.put(PinYinUtils.toPinYin("更新时间"), "更新时间");
+        remapPinYinMap.put(PinYinUtils.toPinYin("当日净值"), "当日净值");
+        remapPinYinMap.put(PinYinUtils.toPinYin("股票名称"), "股票名称");
+        remapPinYinMap.put(PinYinUtils.toPinYin("当前价"), "当前价");
+        remapPinYinMap.put(PinYinUtils.toPinYin("涨跌"), "涨跌");
+        remapPinYinMap.put(PinYinUtils.toPinYin("涨跌幅"), "涨跌幅");
+        remapPinYinMap.put(PinYinUtils.toPinYin("最高价"), "最高价");
+        remapPinYinMap.put(PinYinUtils.toPinYin("最低价"), "最低价");
+        remapPinYinMap.put(PinYinUtils.toPinYin("名称"), "名称");
 
+        remapPinYinMap.put(PinYinUtils.toPinYin("成本价"), "成本价");
+        remapPinYinMap.put(PinYinUtils.toPinYin("持仓"), "持仓");
+        remapPinYinMap.put(PinYinUtils.toPinYin("收益率"), "收益率");
+        remapPinYinMap.put(PinYinUtils.toPinYin("收益"), "收益");
+
+        remapPinYinMap.put(PinYinUtils.toPinYin("持仓成本价"), "持仓成本价");
+        remapPinYinMap.put(PinYinUtils.toPinYin("持有份额"), "持有份额");
     }
 
 
@@ -56,8 +63,8 @@ public class WindowUtils {
         return -1;
     }
 
-    public static String remapPinYin(String pinyin){
-        return remapPinYinMap.getOrDefault(pinyin,pinyin);
+    public static String remapPinYin(String pinyin) {
+        return remapPinYinMap.getOrDefault(pinyin, pinyin);
     }
 
 


### PR DESCRIPTION
支持股票成本价，持仓，收益率，收益显示，设置示例（sh600230,14.4380,1300;sh600008,3.213,1500） 
支持基金持仓成本价，持有份额，收益率，收益显示，设置示例（000123,4.1569,6038.21;sh600008,3.213,1500）
tips:
1.已经调整好代码，更新后设置如果还是以前的格式，向下兼容，不会报错；
2.新的设置用分号隔开基金或股票，逗号接上成本价和持仓。设置示例如上所示，注意去掉括号。